### PR TITLE
fix compatibility with SCOOP 0.7.x

### DIFF
--- a/lib/vsc/mympirun/scoop/bootstrap.py
+++ b/lib/vsc/mympirun/scoop/bootstrap.py
@@ -34,6 +34,7 @@ import runpy
 import sys
 import vsc.processcontrol
 from distutils.version import LooseVersion
+from scoop import __version__ as SCOOP_VERSION
 from scoop import futures
 from scoop.bootstrap.__main__ import Bootstrap
 from vsc.mympirun.scoop.worker_utils import set_scoop_env
@@ -57,12 +58,14 @@ class MyBootstrap(Bootstrap):
                                  default=None
                                  )
 
-        self.parser.add_argument('--nice',
-                                 help="Set this nice level",
-                                 action='store',
-                                 default=0,
-                                 type=int
-                                 )
+        if LooseVersion(SCOOP_VERSION) < LooseVersion('0.7'):
+            # --nice is already there in recent versions of SCOOP
+            self.parser.add_argument('--nice',
+                                     help="Set this nice level",
+                                     action='store',
+                                     default=0,
+                                     type=int
+                                     )
 
         self.parser.add_argument('--affinity',
                                  help="Affinity parameters",
@@ -122,7 +125,10 @@ class MyBootstrap(Bootstrap):
 
     def set_environment(self):
         """Set a number of worker environment variables"""
-        set_scoop_env('worker_name', self.args.workerName)
+        if LooseVersion(SCOOP_VERSION) < LooseVersion('0.7'):
+            set_scoop_env('worker_name', self.args.workerName)
+        else:
+            set_scoop_env('worker_name', self.args.externalBrokerHostname)
         set_scoop_env('worker_origin', int(self.args.origin))
 
     def run(self):

--- a/lib/vsc/mympirun/scoop/myscoop.py
+++ b/lib/vsc/mympirun/scoop/myscoop.py
@@ -76,10 +76,10 @@ class MyHost(Host):
         if not hasattr(self, 'log'):
             self.log = getLogger('MyHost')
 
-    def isLocal(self):
+    #def isLocal(self):
         # force that environment is passed for all workers (including local ones)
         # require because of 'module load' commands (don't play well with subprocess.Popen)
-        return False
+        #return False
 
     def _WorkerCommand_environment(self, worker):
         c = super(MyHost, self)._WorkerCommand_environment(worker)

--- a/lib/vsc/mympirun/scoop/myscoop.py
+++ b/lib/vsc/mympirun/scoop/myscoop.py
@@ -365,7 +365,7 @@ class MYSCOOP(MPI):
         if LooseVersion(SCOOP_VERSION) >= LooseVersion('0.7'):
             scoop_app_args.update({
                 'b': 1,  # total number of brokers to spawn on the hosts, one by default
-                'externalHostName': self.scoop_broker,
+                'externalHostname': self.scoop_broker,
                 'prolog': [None],  # path to prolog script, default is None
                 'backend': 'ZMQ',  # ZMQ or TCP, default: ZMQ
                 #'rsh': False, # added in future version (default: False)
@@ -387,7 +387,7 @@ class MYSCOOP(MPI):
 
         self.log.debug("scoop_run: scoop_app class %s args %s" % (self.SCOOP_APP.__name__, scoop_app_args))
 
-        scoop_app = self.SCOOP_APP(*scoop_app_args)
+        scoop_app = self.SCOOP_APP(**scoop_app_args)
         try:
             root_task_ec = scoop_app.run()
             self.log.debug("scoop_run exited with exitcode %s" % root_task_ec)

--- a/lib/vsc/mympirun/scoop/myscoop.py
+++ b/lib/vsc/mympirun/scoop/myscoop.py
@@ -351,7 +351,7 @@ class MYSCOOP(MPI):
             'arguments': self.scoop_args,
             'debug': self.scoop_debug,
             'env': "other", # TODO check utils.getEnv(),
-            'executable'`: self.scoop_executable,
+            'executable': self.scoop_executable,
             'hosts': [(nodename, len(list(group))) for nodename, group in itertools.groupby(self.scoop_hosts)],
             'n': self.scoop_size,
             'nice': self.scoop_nice,

--- a/lib/vsc/mympirun/scoop/myscoop.py
+++ b/lib/vsc/mympirun/scoop/myscoop.py
@@ -366,7 +366,7 @@ class MYSCOOP(MPI):
             scoop_app_args.update({
                 'b': 1,  # total number of brokers to spawn on the hosts, one by default
                 'externalHostname': self.scoop_broker,
-                'prolog': [None],  # path to prolog script, default is None
+                'prolog': None,  # path to prolog script, default is None
                 'backend': 'ZMQ',  # ZMQ or TCP, default: ZMQ
                 #'rsh': False, # added in future version (default: False)
             })

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ from shared_setup import action_target
 from shared_setup_mympirun import mympirun_vsc_install_scripts
 
 
-VERSION = '3.3.0'
+VERSION = '3.4.0'
 PACKAGE = {
     'name': 'vsc-mympirun-scoop',
     'install_requires': [


### PR DESCRIPTION
This is required to make `myscoop` work on top of SCOOP 0.7.x, due to API changes.

Running the `squares.py` example locally now yields:

```
$ myscoop --sched=local --scoop-module=squares 10000
[2015-09-03 13:05:01,434] launcher  INFO    SCOOP 0.7 1.1 on linux2 using Python 2.7.10 (default, Sep  2 2015, 19:01:27) [GCC Intel(R) C++ gcc 4.9 mode], API: 1013
[2015-09-03 13:05:01,434] launcher  INFO    Deploying 16 worker(s) over 1 host(s).
[2015-09-03 13:05:01,434] launcher  INFO    Worker distribution: 
[2015-09-03 13:05:01,434] launcher  INFO       localhost:   15 + origin
2015-09-03 13:05:04,275 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,275 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,275 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,309 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,321 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,458 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,525 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,529 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,530 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,537 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,538 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,538 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,540 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,542 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,542 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
2015-09-03 13:05:04,542 ERROR      runpy.CpuSetT   MainThread  set_cpus: length cpu list 1024 is larger then cpusetsize 64. Truncating to cpusetsize
First 10000 squares: [0, 1, 4, 9, 16, 25, 36, 49, ...
[2015-09-03 13:05:07,430] launcher  (127.0.0.1:36046) INFO    Root process is done.
[2015-09-03 13:05:07,431] launcher  (127.0.0.1:36046) INFO    Finished cleaning spawned subprocesses.
```

I'm not sure what the `ERROR` is about (yet).

@stdweird: please review
